### PR TITLE
fixed clock-in registration bug

### DIFF
--- a/app/src/main/java/com/rockthevote/grommet/ui/MainActivity.java
+++ b/app/src/main/java/com/rockthevote/grommet/ui/MainActivity.java
@@ -11,14 +11,6 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.widget.Toolbar;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import androidx.core.content.ContextCompat;
-import androidx.legacy.app.ActivityCompat;
-import androidx.lifecycle.ViewModelProvider;
-import androidx.viewpager.widget.ViewPager;
-
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.rockthevote.grommet.R;
 import com.rockthevote.grommet.data.HockeyAppHelper;
@@ -32,9 +24,18 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.widget.Toolbar;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.content.ContextCompat;
+import androidx.legacy.app.ActivityCompat;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.viewpager.widget.ViewPager;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import kotlin.Unit;
 import rx.subscriptions.CompositeSubscription;
 
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
@@ -188,11 +189,28 @@ public final class MainActivity extends BaseActivity {
 
     @OnClick(R.id.fab)
     public void onClick(View v) {
-        //TODO add back in the checks to make sure the user is clocked-in and has no pending registraitons to upload
-        // Also make sure and grab the location data for the specific registration
-        // then create a new voter registration record (or not, still not sure how this is gonna work)
+        viewModel.asyncCanRegister(this::canRegister, this::cantRegister);
+    }
+
+    private Unit canRegister() {
         startActivity(new Intent(this, RegistrationActivity.class),
                 ActivityOptions.makeSceneTransitionAnimation(this).toBundle());
+
+        return Unit.INSTANCE;
+    }
+
+    private Unit cantRegister() {
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.clock_in_alert_title)
+                .setIcon(R.drawable.ic_timer_black_24dp)
+                .setMessage(R.string.clock_in_alert_message)
+                .setPositiveButton(R.string.action_ok, (dialogInterface, i) -> {
+                    dialogInterface.dismiss();
+                })
+                .create()
+                .show();
+
+        return Unit.INSTANCE;
     }
 
     /**

--- a/app/src/main/java/com/rockthevote/grommet/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/com/rockthevote/grommet/ui/MainActivityViewModel.kt
@@ -6,7 +6,6 @@ import com.hadilq.liveevent.LiveEvent
 import com.rockthevote.grommet.data.api.RockyService
 import com.rockthevote.grommet.data.db.dao.RegistrationDao
 import com.rockthevote.grommet.data.db.model.RockyRequest
-import com.rockthevote.grommet.data.db.dao.SessionDao
 import com.rockthevote.grommet.data.db.model.SessionStatus
 import com.rockthevote.grommet.util.SharedPrefKeys.KEY_SESSION_STATUS
 import com.rockthevote.grommet.util.coroutines.DispatcherProvider
@@ -135,6 +134,23 @@ class MainActivityViewModel(
         super.onCleared()
         supervisorJob.cancelChildren()
     }
+
+    fun asyncCanRegister(successCallback: () -> Unit, failCallback: () -> Unit) {
+        viewModelScope.launch(dispatchers.io) {
+            val rawState = sharedPreferences.getString(KEY_SESSION_STATUS, null)
+
+            val status = SessionStatus.fromString(rawState) ?: SessionStatus.PARTNER_UPDATE
+
+            withContext(dispatchers.main) {
+                if (status == SessionStatus.CLOCKED_IN) {
+                    successCallback()
+                } else {
+                    failCallback()
+                }
+            }
+        }
+    }
+
 }
 
 class MainActivityViewModelFactory(

--- a/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTracking.java
+++ b/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTracking.java
@@ -16,9 +16,6 @@ import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.lifecycle.ViewModelProvider;
-
 import com.rockthevote.grommet.R;
 import com.rockthevote.grommet.data.Injector;
 import com.rockthevote.grommet.data.db.dao.PartnerInfoDao;
@@ -30,6 +27,8 @@ import com.rockthevote.grommet.util.Dates;
 
 import javax.inject.Inject;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProvider;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
@@ -248,6 +247,7 @@ public class SessionTimeTracking extends FrameLayout implements EventFlowPage {
     private void clockIn() {
 
         updateUI(CLOCKED_IN);
+        listener.setState(CLOCKED_IN, true);
 
     }
 


### PR DESCRIPTION
https://mechanical-man.atlassian.net/browse/GROM-162


Take a look at the logic in the EventFlowWizard 
![image](https://user-images.githubusercontent.com/1134161/84601523-c8564300-ae4e-11ea-9c8e-ce6a78872f66.png)

does that look OK, the fall-through between details entered and clock in?

Also, I used your high order function trick, since it meant I didn't have to mess w/ the data state classes

