### PR TITLE
GROM-181: Fix previous from final registration Fragment

### DIFF
--- a/app/src/main/java/com/rockthevote/grommet/ui/registration/review/ReviewAndConfirmFragment.java
+++ b/app/src/main/java/com/rockthevote/grommet/ui/registration/review/ReviewAndConfirmFragment.java
@@ -54,6 +54,10 @@ public class ReviewAndConfirmFragment extends BaseRegistrationFragment {
 
     @Override
     public void storeState() {
+        /* Stub */
+    }
+
+    public void completeRegistration() {
         ReviewData data = ReviewExtKt.toReviewData(binding);
         viewModel.completeRegistration(data);
     }
@@ -167,7 +171,7 @@ public class ReviewAndConfirmFragment extends BaseRegistrationFragment {
     @OnClick(R.id.button_register)
     public void onRegisterClick(View v) {
         if (!signaturePad.isEmpty()) {
-            storeState();
+            completeRegistration();
         } else {
             signaturePadError.setVisibility(View.VISIBLE);
         }


### PR DESCRIPTION
Registration completion was being called as a result of `storeState` which isn't applicable for this fragment