### PR TITLE
GROM-183: Fix Political Party "Other" field validation

### DIFF
--- a/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTracking.java
+++ b/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTracking.java
@@ -31,7 +31,6 @@ import androidx.lifecycle.ViewModelProvider;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import timber.log.Timber;
 
 import static com.rockthevote.grommet.data.db.model.SessionStatus.CLOCKED_IN;
 import static com.rockthevote.grommet.data.db.model.SessionStatus.CLOCKED_OUT;

--- a/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTracking.java
+++ b/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTracking.java
@@ -107,6 +107,7 @@ public class SessionTimeTracking extends FrameLayout implements EventFlowPage {
     public void registerCallbackListener(EventFlowCallback listener) {
         this.listener = listener;
         registerDataObservers();
+        viewModel.updateSessionStatus();
     }
 
     @Override
@@ -149,7 +150,7 @@ public class SessionTimeTracking extends FrameLayout implements EventFlowPage {
         }
     }
 
-    void updateUI(SessionStatus status) {
+    private void updateUI(SessionStatus status) {
         switch (status) {
             case CLOCKED_IN: {
 

--- a/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTracking.java
+++ b/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTracking.java
@@ -31,6 +31,7 @@ import androidx.lifecycle.ViewModelProvider;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import timber.log.Timber;
 
 import static com.rockthevote.grommet.data.db.model.SessionStatus.CLOCKED_IN;
 import static com.rockthevote.grommet.data.db.model.SessionStatus.CLOCKED_OUT;

--- a/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTrackingViewModel.kt
+++ b/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTrackingViewModel.kt
@@ -39,15 +39,13 @@ class SessionTimeTrackingViewModel(
         throw throwable
     }
 
-    private val rockyRequestScope = CoroutineScope(dispatchers.io + coroutineExceptionHandler)
-
     private val _effect = LiveEvent<SessionSummaryState.Effect?>()
     val effect: LiveData<SessionSummaryState.Effect?> = _effect
 
     private val _clockState = LiveEvent<ClockEvent>()
     val clockState: LiveData<ClockEvent> = _clockState
 
-    private val _sessionStatus = LiveEvent<SessionStatus>()
+    private val _sessionStatus = MutableLiveData<SessionStatus>()
     val sessionStatus: LiveData<SessionStatus> = _sessionStatus
 
     val sessionData = Transformations.map(partnerInfoDao.getPartnerInfoWithSessionAndRegistrations()) { result ->

--- a/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTrackingViewModel.kt
+++ b/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/SessionTimeTrackingViewModel.kt
@@ -16,7 +16,6 @@ import com.rockthevote.grommet.util.SharedPrefKeys
 import com.rockthevote.grommet.util.coroutines.DispatcherProvider
 import com.rockthevote.grommet.util.coroutines.DispatcherProviderImpl
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -45,7 +44,7 @@ class SessionTimeTrackingViewModel(
     private val _clockState = LiveEvent<ClockEvent>()
     val clockState: LiveData<ClockEvent> = _clockState
 
-    private val _sessionStatus = MutableLiveData<SessionStatus>()
+    private val _sessionStatus = LiveEvent<SessionStatus>()
     val sessionStatus: LiveData<SessionStatus> = _sessionStatus
 
     val sessionData = Transformations.map(partnerInfoDao.getPartnerInfoWithSessionAndRegistrations()) { result ->
@@ -197,7 +196,7 @@ class SessionTimeTrackingViewModel(
         }
     }
 
-    private fun updateSessionStatus() {
+    fun updateSessionStatus() {
         viewModelScope.launch(dispatchers.io) {
             val statusString = sharedPreferences.getString(SharedPrefKeys.KEY_SESSION_STATUS, null) ?: return@launch
             val status = SessionStatus.fromString(statusString) ?: return@launch

--- a/app/src/main/java/com/rockthevote/grommet/ui/registration/RegistrationActivity.java
+++ b/app/src/main/java/com/rockthevote/grommet/ui/registration/RegistrationActivity.java
@@ -181,11 +181,6 @@ public class RegistrationActivity extends BaseActivity {
         int curPage = viewPager.getCurrentItem();
         if (curPage > 0) {
             int previousItem = curPage - 1;
-
-            BaseRegistrationFragment currentFragment =
-                    ((BaseRegistrationFragment) adapter.getItem(curPage));
-            currentFragment.storeState();
-
             viewPager.setCurrentItem(previousItem);
         }
     }


### PR DESCRIPTION
We were saving state on previous click to the ViewModel, this is unnecessary as the Fragment state is reasonable retained without this. This caused the default "Other" behavior to be populated into the data object on "previous" click.

This also addresses a lifecycle bug I found when testing state retention. The "Clock in/out" button was not being properly set on configuration change (tested via turning power save mode on), this ensures that the session status is retained as a state rather than an event so it can be properly observed on configuration change.