### PR TITLE
GROM-186

### DIFF
--- a/app/src/main/java/com/rockthevote/grommet/data/db/dao/PartnerInfoDao.kt
+++ b/app/src/main/java/com/rockthevote/grommet/data/db/dao/PartnerInfoDao.kt
@@ -18,6 +18,9 @@ interface PartnerInfoDao {
     @Query("SELECT * FROM partner_info LIMIT 1")
     fun getCurrentPartnerInfoLive(): LiveData<PartnerInfo>
 
+    @Query("SELECT * FROM partner_info WHERE partner_info_id = :partnerInfoId LIMIT 1")
+    fun getPartnerInfo(partnerInfoId: Long?): PartnerInfo
+
     @Query("SELECT * FROM partner_info LIMIT 1")
     fun getCurrentPartnerInfo(): PartnerInfo
 

--- a/app/src/main/java/com/rockthevote/grommet/data/db/model/PartnerInfo.kt
+++ b/app/src/main/java/com/rockthevote/grommet/data/db/model/PartnerInfo.kt
@@ -18,7 +18,7 @@ data class PartnerInfo(
 
         // the key to login as this partner
         @ColumnInfo(name = "partner_id")
-        val partnerId: String,
+        val partnerId: Long,
 
         @ColumnInfo(name = "app_version")
         val appVersion: Float,

--- a/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/EventPartnerLogin.java
+++ b/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/EventPartnerLogin.java
@@ -127,10 +127,10 @@ public class EventPartnerLogin extends FrameLayout implements EventFlowPage {
                     }
                 });
 
-        viewModel.getPartnerInfoId().observe(
+        viewModel.getPartnerInfoPartnerID().observe(
                 (AppCompatActivity) getContext(), id -> {
-                    if (!id.equals("-1")) {
-                        edePartnerId.setText(id);
+                    if (id != -1) {
+                        edePartnerId.setText(String.valueOf(id));
                     } else {
                         edePartnerId.setText("");
                     }
@@ -145,7 +145,7 @@ public class EventPartnerLogin extends FrameLayout implements EventFlowPage {
         inputMethodManager.hideSoftInputFromWindow(v.getWindowToken(), 0);
 
         if (validator.validate().toBlocking().single()) {
-            viewModel.validatePartnerId(edePartnerId.getText().toString());
+            viewModel.validatePartnerId(Long.parseLong(edePartnerId.getText().toString()));
         }
     }
 

--- a/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/PartnerLoginViewModel.kt
+++ b/app/src/main/java/com/rockthevote/grommet/ui/eventFlow/PartnerLoginViewModel.kt
@@ -24,9 +24,9 @@ class PartnerLoginViewModel(
         private val sessionDao: SessionDao
 ) : ViewModel() {
 
-    val partnerInfoId: LiveData<String> =
+    val partnerInfoPartnerID: LiveData<Long> =
             Transformations.map(partnerInfoDao.getCurrentPartnerInfoLive()) { result ->
-                result?.partnerId ?: "-1"
+                result?.partnerId ?: -1
             }
 
     private val _partnerLoginState = MutableLiveData<PartnerLoginState>(PartnerLoginState.Init)
@@ -40,10 +40,10 @@ class PartnerLoginViewModel(
         setStateToError()
     }
 
-    fun validatePartnerId(partnerId: String) {
+    fun validatePartnerId(partnerId: Long) {
         updateState(PartnerLoginState.Loading)
 
-        if (partnerId.equals(partnerInfoId.value)) {
+        if (partnerId == partnerInfoPartnerID.value) {
             // just continue on if the value is the same
             updateState(PartnerLoginState.Init)
             updateEffect(PartnerLoginState.Success)
@@ -82,8 +82,8 @@ class PartnerLoginViewModel(
     }
 
     private fun completePartnerValidation(
-        partnerId: String,
-        partnerNameResponse: PartnerNameResponse
+            partnerId: Long,
+            partnerNameResponse: PartnerNameResponse
     ): PartnerLoginState.Effect {
         partnerInfoDao.deleteAllPartnerInfo()
         sessionDao.clearAllSessionInfo()

--- a/app/src/main/java/com/rockthevote/grommet/ui/registration/BaseRegistrationFragment.java
+++ b/app/src/main/java/com/rockthevote/grommet/ui/registration/BaseRegistrationFragment.java
@@ -1,25 +1,25 @@
 package com.rockthevote.grommet.ui.registration;
 
 import android.os.Bundle;
-import androidx.annotation.LayoutRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.cardview.widget.CardView;
-import androidx.lifecycle.ViewModelProvider;
-
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.rockthevote.grommet.R;
 import com.rockthevote.grommet.data.Injector;
+import com.rockthevote.grommet.data.db.dao.PartnerInfoDao;
 import com.rockthevote.grommet.data.db.dao.RegistrationDao;
 import com.rockthevote.grommet.data.db.dao.SessionDao;
 import com.rockthevote.grommet.databinding.FragmentRegistrationBaseBinding;
 
 import javax.inject.Inject;
 
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.cardview.widget.CardView;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 import rx.Observable;
 
 public abstract class BaseRegistrationFragment extends Fragment {
@@ -34,13 +34,16 @@ public abstract class BaseRegistrationFragment extends Fragment {
     @Inject
     SessionDao sessionDao;
 
+    @Inject
+    PartnerInfoDao partnerInfoDao;
+
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         Injector.obtain(getActivity()).inject(this);
         viewModel = new ViewModelProvider(
                 requireActivity(),
-                new RegistrationViewModelFactory(registrationDao, sessionDao)
+                new RegistrationViewModelFactory(registrationDao, sessionDao, partnerInfoDao)
         ).get(RegistrationViewModel.class);
     }
 

--- a/app/src/main/java/com/rockthevote/grommet/ui/registration/RegistrationActivity.java
+++ b/app/src/main/java/com/rockthevote/grommet/ui/registration/RegistrationActivity.java
@@ -14,6 +14,7 @@ import android.widget.LinearLayout;
 import com.google.android.material.appbar.AppBarLayout;
 import com.rockthevote.grommet.R;
 import com.rockthevote.grommet.data.Injector;
+import com.rockthevote.grommet.data.db.dao.PartnerInfoDao;
 import com.rockthevote.grommet.data.db.dao.RegistrationDao;
 import com.rockthevote.grommet.data.db.dao.SessionDao;
 import com.rockthevote.grommet.ui.BaseActivity;
@@ -44,6 +45,8 @@ public class RegistrationActivity extends BaseActivity {
     @Inject RegistrationDao registrationDao;
 
     @Inject SessionDao sessionDao;
+
+    @Inject PartnerInfoDao partnerInfoDao;
 
     @BindView(R.id.appbar) AppBarLayout appbar;
     @BindView(R.id.toolbar) Toolbar toolbar;
@@ -76,7 +79,7 @@ public class RegistrationActivity extends BaseActivity {
 
         viewModel = new ViewModelProvider(
                 this,
-                new RegistrationViewModelFactory(registrationDao, sessionDao)
+                new RegistrationViewModelFactory(registrationDao, sessionDao, partnerInfoDao)
         ).get(RegistrationViewModel.class);
 
         ViewGroup contentView = getContentView();

--- a/app/src/test/java/com/rockthevote/grommet/testdata/FakePartnerInfoDao.kt
+++ b/app/src/test/java/com/rockthevote/grommet/testdata/FakePartnerInfoDao.kt
@@ -1,0 +1,46 @@
+package com.rockthevote.grommet.testdata
+
+import androidx.lifecycle.LiveData
+import com.rockthevote.grommet.data.db.dao.PartnerInfoDao
+import com.rockthevote.grommet.data.db.model.PartnerInfo
+import com.rockthevote.grommet.data.db.relationship.PartnerInfoWithSession
+import com.rockthevote.grommet.data.db.relationship.PartnerInfoWithSessionAndRegistrations
+
+class FakePartnerInfoDao(
+        private val currentPartnerInfo: PartnerInfo
+) : PartnerInfoDao {
+
+    override fun getCurrentPartnerInfoLive(): LiveData<PartnerInfo> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPartnerInfo(partnerInfoId: Long?): PartnerInfo {
+        return currentPartnerInfo
+    }
+
+    override fun getCurrentPartnerInfo(): PartnerInfo {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAll(): List<PartnerInfo> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPartnerInfoWithSession(): LiveData<PartnerInfoWithSession?> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPartnerInfoWithSessionAndRegistrations(): LiveData<PartnerInfoWithSessionAndRegistrations?> {
+        TODO("Not yet implemented")
+    }
+
+    override fun insertPartnerInfo(partnerInfo: PartnerInfo) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteAllPartnerInfo() {
+        TODO("Not yet implemented")
+    }
+
+
+}


### PR DESCRIPTION
fix partner ID reference during registration request generation

We were grabbing the partnerInfoId column value from the SessionDAO object, which is just the foreign key to the row in the PartnerInfo table, and since that is a 1 row table the value is always 0.

Updated code to get the partner_id column value from the PartnerInfo table.